### PR TITLE
Add Sendable support for Swift 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Swift micro library providing simple HTTP service abstractions. It defines a `ServiceProtocol` describing an endpoint and utilities for building and executing `URLRequest`s. It also includes helpers for multipart uploads and request interception.
 
+This version of the library requires Swift 6 and adopts concurrency safety through the `Sendable` protocol.
+
 ## Installation
 
 Add the package to your `Package.swift` dependencies:

--- a/Sources/ServiceAuthorizable/AuthorizableType.swift
+++ b/Sources/ServiceAuthorizable/AuthorizableType.swift
@@ -1,5 +1,5 @@
 /// Defines the authorization requirements for a service.
-public enum AuthorizableType: Equatable {
+public enum AuthorizableType: Equatable, Sendable {
     /// No authorization required.
     case none
     /// Uses a token without a specific resource.

--- a/Sources/ServiceAuthorizable/ServiceProtocolAuthorizable.swift
+++ b/Sources/ServiceAuthorizable/ServiceProtocolAuthorizable.swift
@@ -1,5 +1,5 @@
 /// Describes a service capable of providing authorization configuration.
-public protocol ServiceProtocolAuthorizable {
+public protocol ServiceProtocolAuthorizable: Sendable {
     /// Returns the ``AuthorizableType`` required by the service.
     func authorizableType() -> AuthorizableType
 }

--- a/Sources/ServiceLibrary/BodyParameterEncoding.swift
+++ b/Sources/ServiceLibrary/BodyParameterEncoding.swift
@@ -1,5 +1,5 @@
 /// A type used to define how a set of parameters are applied to a `URLRequest`.
-public enum BodyParameterEncoding: String {
+public enum BodyParameterEncoding: String, Sendable {
     /// Sets encoded query string result as the HTTP body of the URL request.
     case formUrlEncoded = "application/x-www-form-urlencoded"
 

--- a/Sources/ServiceLibrary/HTTPHeader.swift
+++ b/Sources/ServiceLibrary/HTTPHeader.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A representation of a single HTTP header's name / value pair.
-public struct HTTPHeader: Hashable {
+public struct HTTPHeader: Hashable, Sendable {
     /// Name of the header.
     public let name: String
 

--- a/Sources/ServiceLibrary/HTTPHeaders.swift
+++ b/Sources/ServiceLibrary/HTTPHeaders.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// An order-preserving and case-insensitive representation of HTTP headers.
-public struct HTTPHeaders {
+public struct HTTPHeaders: Sendable {
     private var headers: [HTTPHeader] = []
 
     /// Creates an empty instance.

--- a/Sources/ServiceLibrary/HTTPMethod.swift
+++ b/Sources/ServiceLibrary/HTTPMethod.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// HTTP method definitions.
 /// See https://tools.ietf.org/html/rfc7231#section-4.3
-public enum HTTPMethod: String {
+public enum HTTPMethod: String, Sendable {
     case options = "OPTIONS"
     case get = "GET"
     case head = "HEAD"

--- a/Sources/ServiceLibrary/Interceptor/Interceptor.swift
+++ b/Sources/ServiceLibrary/Interceptor/Interceptor.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol Interceptor {
+public protocol Interceptor: Sendable {
     func adapt(
         _ urlRequest: URLRequest,
         for session: URLSessionProtocol

--- a/Sources/ServiceLibrary/Interceptor/InterceptorsStorage.swift
+++ b/Sources/ServiceLibrary/Interceptor/InterceptorsStorage.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct InterceptorsStorage {
+public struct InterceptorsStorage: Sendable {
     private var interceptors: [Interceptor]
 
     public init(interceptors: [Interceptor]) {

--- a/Sources/ServiceLibrary/Interceptor/RetryInterceptor.swift
+++ b/Sources/ServiceLibrary/Interceptor/RetryInterceptor.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct RetryInterceptor: Interceptor {
+public struct RetryInterceptor: Interceptor, Sendable {
     /// The maximum number of retry attempts.
     private let retryCount: Int
     /// The HTTP status codes that should trigger a retry.

--- a/Sources/ServiceLibrary/MultipartFormData/BoundaryGenerator.swift
+++ b/Sources/ServiceLibrary/MultipartFormData/BoundaryGenerator.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-enum BoundaryGenerator {
+enum BoundaryGenerator: Sendable {
     typealias EncodingCharacters = MultipartFormData.EncodingCharacters
 
-    enum BoundaryType {
+    enum BoundaryType: Sendable {
         case initial, encapsulated, final
     }
 

--- a/Sources/ServiceLibrary/MultipartFormData/MultipartEncodingError.swift
+++ b/Sources/ServiceLibrary/MultipartFormData/MultipartEncodingError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum MultipartEncodingError: Error {
+public enum MultipartEncodingError: Error, Sendable {
     case unexpectedInputStreamLength(bytesExpected: UInt64, bytesRead: UInt64)
 
     /// The `fileURL` provided for reading an encodable body part isn't a file `URL`.

--- a/Sources/ServiceLibrary/MultipartFormData/MultipartFormData.swift
+++ b/Sources/ServiceLibrary/MultipartFormData/MultipartFormData.swift
@@ -18,14 +18,14 @@ import Foundation
 /// - https://www.ietf.org/rfc/rfc2388.txt
 /// - https://www.ietf.org/rfc/rfc2045.txt
 /// - https://www.w3.org/TR/html401/interact/forms.html#h-17.13
-open class MultipartFormData {
+open class MultipartFormData: @unchecked Sendable {
     // MARK: - Helper Types
 
     enum EncodingCharacters {
         static let crlf = "\r\n"
     }
 
-    class BodyPart {
+    class BodyPart: @unchecked Sendable {
         let headers: HTTPHeaders
         let bodyStream: InputStream
         let bodyContentLength: UInt64

--- a/Sources/ServiceLibrary/Plugin/AuthorizationPlugin.swift
+++ b/Sources/ServiceLibrary/Plugin/AuthorizationPlugin.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-public protocol AuthorizationPlugin {
+public protocol AuthorizationPlugin: Sendable {
     func prepare(_ request: URLRequest, service: any ServiceProtocol) -> URLRequest
 }

--- a/Sources/ServiceLibrary/ServiceProtocol+perform.swift
+++ b/Sources/ServiceLibrary/ServiceProtocol+perform.swift
@@ -1,7 +1,7 @@
 import Combine
 import Foundation
 
-public protocol URLSessionProtocol {
+public protocol URLSessionProtocol: Sendable {
     func data(for request: URLRequest) async throws -> (Data, URLResponse)
 }
 

--- a/Sources/ServiceLibrary/ServiceProtocol.swift
+++ b/Sources/ServiceLibrary/ServiceProtocol.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public protocol ServiceProtocol {
+public protocol ServiceProtocol: Sendable {
     /// The target's base `URL`.
     var baseURL: URL? { get }
 

--- a/Sources/ServiceLibrary/ServiceProtocolError.swift
+++ b/Sources/ServiceLibrary/ServiceProtocolError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum ServiceProtocolError: Error {
+public enum ServiceProtocolError: Error, Sendable {
     case invalidURL
     /// ResponseCode
     case responseCode(Int)

--- a/Tests/ServiceLibraryTests/KYCService.swift
+++ b/Tests/ServiceLibraryTests/KYCService.swift
@@ -2,7 +2,7 @@ import Foundation
 import ServiceLibrary
 
 @Service(baseURL: "https://www.mock.com")
-enum KYCService {
+enum KYCService: Sendable {
     @Get(endpoint: "/users")
     case status
 }

--- a/Tests/ServiceLibraryTests/RetryInterceptorsTests.swift
+++ b/Tests/ServiceLibraryTests/RetryInterceptorsTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 import XCTest
 
-struct EmptyModel: Codable {}
+struct EmptyModel: Codable, Sendable {}
 
 class RetryInterceptorTests: XCTestCase {
     var sut: ServiceProtocol! // System Under Test
@@ -36,7 +36,7 @@ class RetryInterceptorTests: XCTestCase {
 }
 
 // Mock URLSession
-class MockURLSession: URLSessionProtocol {
+final class MockURLSession: URLSessionProtocol, Sendable {
     var mockData: Data?
     var mockResponse: URLResponse?
     var mockError: Error?

--- a/Tests/ServiceLibraryTests/ServiceLibraryTests.swift
+++ b/Tests/ServiceLibraryTests/ServiceLibraryTests.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import ServiceLibrary
 import XCTest
 
-enum MockService {
+enum MockService: Sendable {
     case getUsers
 }
 


### PR DESCRIPTION
## Summary
- mark various protocols, structs, and enums as `Sendable`
- make multipart helpers `@unchecked Sendable`
- update tests with `Sendable` types
- document Swift 6 requirement

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/swiftlang/swift-syntax: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6840174853488329a1b07e455fb1876e